### PR TITLE
Fixed bug allowing for more than 5 seed genres

### DIFF
--- a/src/server/utils/emojiDict.test.ts
+++ b/src/server/utils/emojiDict.test.ts
@@ -30,4 +30,14 @@ describe("generateRecommendationsURL", () => {
     expect(url).toContain('target_danceability=0.5'); // Example check, adjust based on actual logic
     expect(url).toContain('target_instrumentalness=0');
   });
+
+  it('should generate a correct URL with no more than 5 genres', () => {
+
+    const emojis = "🇧🇷🇯🇵" // Assuming this generates a fixed sequence now due to mocks
+    
+    const url = generateRecommendationsURL(emojis);
+    const genresString =["bossanova", "brazil", "forro", "mpb", "pagode"].join("%2C")
+    
+    expect(url).toContain(`seed_genres=${genresString}`);    
+  });
 })

--- a/src/server/utils/emojiDict.ts
+++ b/src/server/utils/emojiDict.ts
@@ -264,7 +264,7 @@ export const generateRecommendationsURL = (emojis: string): string => {
 
   const buildGenreQuery = (genres: string[]): string => {
     // Handle duplicate genre entries
-    const genreSet = new Set(genres);
+    const genreSet = new Set(genres.slice(0,5));
     const genreList = Array.from(genreSet).join(",")
     return "seed_genres=" + encodeURIComponent(genreList)
   }

--- a/src/server/utils/emojiDict.ts
+++ b/src/server/utils/emojiDict.ts
@@ -1,4 +1,4 @@
-import { randomInteger, randomElement } from './helpers'
+import { randomInteger, randomElement, randomFloat } from './helpers'
 import GraphemeSplitter from 'grapheme-splitter';
 
 const splitter = new GraphemeSplitter()
@@ -18,6 +18,21 @@ interface Metric {
 
 interface MetricsObject {
   [key: string]: Metric;
+}
+
+type Metrics = {
+  acousticness?: number
+  danceability?: number
+  energy?: number
+  instrumentalness?: number
+  liveness?: number
+  loudness?: number
+  mode?: number
+  speechiness?: number
+  tempo?: number
+  valence?: number
+  key?: number
+  time_signature?: number
 }
 
 export const genresMap: GenreMap = {
@@ -141,6 +156,8 @@ export const genresMap: GenreMap = {
   "🌎": { type: "genre", value: "world-music" },
 };
 
+
+// TODO Delete if not used
 const metricsMap: MetricsMap = {
   "😐": {
     type: "danceability",
@@ -224,14 +241,93 @@ const metricsMap: MetricsMap = {
   },
 }
 
+const metricsOptionObj : any = {
+  "danceability": {
+    min: 0,
+    max: 1,
+    type: "float"
+  },
+  "instrumentalness" : {
+    min: 0,
+    max: 1,
+    type: "float"
+  },
+  "energy" :{
+    min: 0,
+    max: 1,
+    type: "float"
+  },
+  "key" : {
+    min: 0,
+    max: 11,
+    type: "integer"
+  },
+  "time_signature": {
+    min: 3,
+    max: 7,
+    type: "integer",
+  },
+  "mode" : {
+    min: 0,
+    max: 1,
+    type: "integer"
+  },
+  "liveness": {
+    min: 0,
+    max: 1,
+    type: "float"
+  },
+  "valence" : {
+    min: 0,
+    max: 1,
+    type: "float"
+  },
+  "loudness" :{
+    min: -60,
+    max: 0,
+    type: "float"
+  },
+  "tempo" : {
+    min: 0,
+    max: 240,
+    type: "float"
+  },
+}
+
+
+
+
+
 const recommendationsURL = "https://api.spotify.com/v1/recommendations"
+
+export const createRandomGenreEmoji = () : string => {
+  const genresOptions = Object.keys(genresMap);
+  const numGenres = randomInteger(1, 5);
+  const genres = Array.from({ length: numGenres }, () => randomElement(genresOptions));
+  return genres.join("");  
+}
+
+export const createRandomMetricsObject = () => {
+  const metricsOptions = Object.keys(metricsOptionObj);
+  const metricsObject : any = {};  
+  const numMetrics = randomInteger(1,5);
+  const metrics = Array.from({length: numMetrics}, () => randomElement(metricsOptions))
+
+  for (const metric of metrics) {  
+    metricsObject[metric] = metricsOptionObj[metric].type === "integer" ? randomInteger(metricsOptionObj[metric].min,metricsOptionObj[metric].max) : randomFloat(metricsOptionObj[metric].min,metricsOptionObj[metric].max)
+  }
+  return metricsObject;
+}
+
+
+
 
 export const createRandomEmojiQuery = (): string => {
   const genresOptions = Object.keys(genresMap);
   const metricsOptions = Object.keys(metricsMap);
 
   const numGenres = randomInteger(1, 5);
-  const numMetrics = randomInteger(1, 10);
+  const numMetrics = randomInteger(1,10);
 
   const genres = Array.from({ length: numGenres }, () => randomElement(genresOptions));
   const metrics = Array.from({ length: numMetrics }, () => randomElement(metricsOptions));
@@ -297,3 +393,16 @@ export const generateRecommendationsURL = (emojis: string): string => {
 }
 
 
+const metricsTestObj = {
+  danceability : .5,
+  tempo: 120,
+  loudness: -60,
+  valence: .5,
+  speechiness: .2,
+}
+
+const parseMetrics = (metricsObj: any) => {
+  return "&" + Object.entries(metricsObj).map(([metric,value],i)=>{
+    return `target_${metric}=${value}`;
+  }).join('&')
+}

--- a/src/server/utils/helpers.ts
+++ b/src/server/utils/helpers.ts
@@ -1,3 +1,5 @@
+import e from "express";
+
 export const randomElement = (array : string[]) => {
   if (array.length === 0) {
     throw new Error("Array cannot be empty");
@@ -11,4 +13,9 @@ export const randomInteger = (min: number, max: number): number => {
   }
   return min + Math.floor(Math.random() * (max - min + 1));
 };
+
+export const randomFloat = (min: number, max: number) : number => {
+  if (min === max) return min;
+  return min + Math.random() * (max - min + 1);
+}
 


### PR DESCRIPTION
## Overview
Seed genres must be limited to five.

**Issue Type**
Fixed bug that was allowing more than 5 genres to be use as seeds. 

- [ X] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
I slice the array of seed genres to limit the size of the array to be five. 

**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**

1. Go to buildGenerQueryMethod in the emjoDict.ts
2. The genreSet has the slice method.

**Previous behavior**
A clear and concise description of what was originally happening.

**Expected behavior**
A clear and concise description of what you expected to happen.

**Screenshots & Videos**
If applicable, add screenshots and videos to help explain your issue type.

**Additional context**
Add any other context about the problem he
